### PR TITLE
Add build arguments for osxcross installation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,25 +51,38 @@ RUN apt-get install -y mingw-w64 \
 
 
 # Install OSx cross-tools
-ENV OSXCROSS_REVISION=a845375e028d29b447439b0c65dea4a9b4d2b2f6  \
-    DARWIN_SDK_VERSION=10.10                                    \
-    DARWIN_VERSION=14
+
+#Build arguments
+ARG osxcross_repo="tpoechtrager/osxcross"
+ARG osxcross_revision="a845375e028d29b447439b0c65dea4a9b4d2b2f6"
+ARG darwin_sdk_version="10.10"
+ARG darwin_osx_version_min="10.6"
+ARG darwin_version="14"
+ARG darwin_sdk_url="https://www.dropbox.com/s/yfbesd249w10lpc/MacOSX${darwin_sdk_version}.sdk.tar.xz"
+
+# ENV available in docker image
+ENV OSXCROSS_REPO="${osxcross_repo}"                   \
+    OSXCROSS_REVISION="${osxcross_revision}"           \
+    DARWIN_SDK_VERSION="${darwin_sdk_version}"         \
+    DARWIN_VERSION="${darwin_version}"                 \
+    DARWIN_OSX_VERSION_MIN="${darwin_osx_version_min}" \
+    DARWIN_SDK_URL="${darwin_sdk_url}"
 
 RUN mkdir -p "/tmp/osxcross"                                                                                   \
  && cd "/tmp/osxcross"                                                                                         \
- && curl -sLo osxcross.tar.gz "https://codeload.github.com/tpoechtrager/osxcross/tar.gz/${OSXCROSS_REVISION}"  \
+ && curl -sLo osxcross.tar.gz "https://codeload.github.com/${OSXCROSS_REPO}/tar.gz/${OSXCROSS_REVISION}"  \
  && tar --strip=1 -xzf osxcross.tar.gz                                                                         \
  && rm -f osxcross.tar.gz                                                                                      \
  && curl -sLo tarballs/MacOSX${DARWIN_SDK_VERSION}.sdk.tar.xz                                                  \
-        "https://www.dropbox.com/s/yfbesd249w10lpc/MacOSX${DARWIN_SDK_VERSION}.sdk.tar.xz"                     \
- && yes "" | SDK_VERSION="${DARWIN_SDK_VERSION}" OSX_VERSION_MIN=10.6 ./build.sh                               \
+             "${DARWIN_SDK_URL}"                \
+ && yes "" | SDK_VERSION="${DARWIN_SDK_VERSION}" OSX_VERSION_MIN="${DARWIN_OSX_VERSION_MIN}" ./build.sh                               \
  && mv target /usr/osxcross                                                                                    \
  && mv tools /usr/osxcross/                                                                                    \
  && ln -sf ../tools/osxcross-macports /usr/osxcross/bin/omp                                                    \
  && ln -sf ../tools/osxcross-macports /usr/osxcross/bin/osxcross-macports                                      \
  && ln -sf ../tools/osxcross-macports /usr/osxcross/bin/osxcross-mp                                            \
  && rm -rf /tmp/osxcross                                                                                       \
- && rm -rf /usr/osxcross/SDK/MacOSX10.10.sdk/usr/share/man
+ && rm -rf "/usr/osxcross/SDK/MacOSX${DARWIN_SDK_VERSION}.sdk/usr/share/man"
 
 
 # Create symlinks for triples and set default CROSS_TRIPLE
@@ -113,4 +126,3 @@ ENTRYPOINT ["/usr/bin/crossbuild"]
 CMD ["/bin/bash"]
 WORKDIR /workdir
 COPY ./assets/crossbuild /usr/bin/crossbuild
-


### PR DESCRIPTION
With the change it is possible to use our own SDK version and latest osxcross.