### PR TITLE
add qemu-user-static to the list of packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get install -y -q                              \
         wget                                           \
         xz-utils                                       \
         cmake                                          \
+        qemu-user-static                               \
  && apt-get clean
 # FIXME: install gcc-multilib
 # FIXME: add mips and powerpc architectures


### PR DESCRIPTION
I added this because I ran into a problem when trying to build `busybox`:
In the build process, busybox compiles helpers that it uses to do some building tasks, and it fails when building for a different architecture than the hosts, because there is no way for the container to execute these compiled binaries.

With this addition, you can `docker run --rm --privileged multiarch/qemu-user-static:register` on the host to register qemu-user-static tools in the binfmt_misc facility, then run your crossbuild container. This way, `busybox` can compile without problems.