### PR TITLE
Fix passing multiple arguments to bash -c as a command

### DIFF
--- a/assets/crossbuild
+++ b/assets/crossbuild
@@ -51,5 +51,5 @@ if [ -n "${CROSS_TRIPLE}" -a -f "${CROSS_ROOT}/bin/$binary" ]; then
 fi
 
 # finally exec
-exec "${binary}" $@
+exec "${binary}" "$@"
 exit $?


### PR DESCRIPTION
Similar to https://github.com/docker/toolbox/issues/368 , when evoking `docker run crossbuild bash -c "foo bar"`, bash only ends up getting "foo".  Not sure why this fixes it, but this is the fix they applied to the official Docker Toolbox to fix the same issue, and seems to work =).

Example of problem:
```
user@HOST MINGW64 ~
$ docker run -it --rm multiarch/crossbuild sh -c "echo hi"


user@HOST MINGW64 ~
$ docker run -it --rm busybox sh -c "echo hi"
hi

```

Note: (ba)sh -c is required if your build command is something like "mkdir -p /workdir/foo && cd /workdir/foo && cmake .. && make"
Also, this may only be a bug/issue when running Docker Toolbox on Windows.