### PR TITLE
Upgrade to debian stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-FROM buildpack-deps:jessie-curl
+FROM buildpack-deps:stretch-curl
 MAINTAINER Manfred Touron <m@42.am> (https://github.com/moul)
 
 # Install deps
 RUN set -x; \
-    echo deb http://emdebian.org/tools/debian/ jessie main > /etc/apt/sources.list.d/emdebian.list \
- && curl -sL http://emdebian.org/tools/debian/emdebian-toolchain-archive.key | apt-key add - \
- && dpkg --add-architecture arm64                      \
+    dpkg --add-architecture arm64                      \
  && dpkg --add-architecture armel                      \
  && dpkg --add-architecture armhf                      \
  && dpkg --add-architecture i386                       \
@@ -38,8 +36,6 @@ RUN set -x; \
         mercurial                                      \
         multistrap                                     \
         patch                                          \
-        python-software-properties                     \
-        software-properties-common                     \
         subversion                                     \
         wget                                           \
         xz-utils                                       \
@@ -59,7 +55,7 @@ RUN apt-get install -y mingw-w64 \
 
 #Build arguments
 ARG osxcross_repo="tpoechtrager/osxcross"
-ARG osxcross_revision="a845375e028d29b447439b0c65dea4a9b4d2b2f6"
+ARG osxcross_revision="d6acb50babc2904ccc1e473723f2551ad211e6ea"
 ARG darwin_sdk_version="10.10"
 ARG darwin_osx_version_min="10.6"
 ARG darwin_version="14"


### PR DESCRIPTION
* Jessie is EOL was on 2018-06-17
* Jessie packages are outdated (ie, no jdk-11)
* Emdebian was dead since 2013
* osxcross is upgraded to the latest commit hash

The DarwinSDK needs to be updated (who owns that Dropbox link?), otherwise build fails:
```
In file included from code-sign-blobs/blob.cpp:29:
In file included from code-sign-blobs/blob.h:45:
In file included from code-sign-blobs/endian.h:34:
code-sign-blobs/memutils.h:96:42: error: unknown type name 'ptrdiff_t'; did you mean 'std::ptrdiff_t'?
inline const T *increment(const void *p, ptrdiff_t offset)
                                         ^~~~~~~~~
                                         std::ptrdiff_t
/usr/bin/../lib/gcc/x86_64-linux-gnu/6.3.0/../../../../include/x86_64-linux-gnu/c++/6.3.0/bits/c++config.h:202:28: note: 'std::ptrdiff_t' declared here
  typedef __PTRDIFF_TYPE__      ptrdiff_t;
                                ^
```