### PR TITLE
Fix intinite loop of cmake wrapper of osxcross.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,6 +87,7 @@ RUN mkdir -p "/tmp/osxcross"                                                    
  && ln -sf ../tools/osxcross-macports /usr/osxcross/bin/omp                                                    \
  && ln -sf ../tools/osxcross-macports /usr/osxcross/bin/osxcross-macports                                      \
  && ln -sf ../tools/osxcross-macports /usr/osxcross/bin/osxcross-mp                                            \
+ && sed -i -e "s%exec cmake%exec /usr/bin/cmake%" /usr/osxcross/bin/osxcross-cmake                             \
  && rm -rf /tmp/osxcross                                                                                       \
  && rm -rf "/usr/osxcross/SDK/MacOSX${DARWIN_SDK_VERSION}.sdk/usr/share/man"
 


### PR DESCRIPTION
Running cmake in the container with `CROSS_TRIPLE=x86_64-apple-darwin` hangs. The cause is wrapper of cmake (osxcross-cmake). Running cmake in the script results in recursively calling itself due to the PATH in the container.
```
root@6955a97b22e3:/workdir# /usr/bin/cmake --version
cmake version 3.7.2

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```
```
root@6955a97b22e3:/workdir# which cmake
/usr/x86_64-apple-darwin14/bin/cmake
```
```
root@6955a97b22e3:/workdir# cat /usr/x86_64-apple-darwin14/bin/cmake
#!/bin/bash

# set -x

# check if we are a symlink
if [ "$(readlink -f $0)" != "$0" ]; then
    exec "$(readlink -f $0)" $@
    exit $?
fi

# normal behavior -> proxy to osxcross binary
triple=$(echo "$0" | cut -d/ -f3)
binary=$(basename "$0")
binary_path="/usr/osxcross/bin/$triple-$binary"

exec "$binary_path" $@
```
```
# ls -l /usr/osxcross/bin/x86_64-apple-darwin14-cmake
lrwxrwxrwx. 1 root root 14 Oct 20 12:29 /usr/osxcross/bin/x86_64-apple-darwin14-cmake -> osxcross-cmake
```
```
root@6955a97b22e3:/workdir# cat /usr/osxcross/bin/osxcross-cmake
#!/usr/bin/env bash
set -e

dir=`dirname "$0"`
progname=`basename "$0"`

host=${progname%-cmake}
if test "$host" = "osxcross" ; then
   echo "Do not invoke this script directly."
   exit 1
fi

eval "`$dir/$host-osxcross-conf`"
export OSXCROSS_HOST="$host"

exec cmake -DCMAKE_TOOLCHAIN_FILE="$OSXCROSS_TARGET_DIR"/toolchain.cmake "$@"
```
